### PR TITLE
Updated prereqs to include S3 bucket and Cognito Identity Pool

### DIFF
--- a/Scenario1/README.md
+++ b/Scenario1/README.md
@@ -8,6 +8,10 @@ This first scenario is less complex; for many organizational requirements, it mi
 # Prerequsites
 This template will setup a sample application using SAML for authentication. It assumes you are using the following prerequsite blog: https://aws.amazon.com/blogs/security/enabling-federation-to-aws-using-windows-active-directory-adfs-and-saml-2-0/
 
+Prior to installation, you should setup the following in your AWS account:
+  * An S3 bucket in which to store the provided Serverless template
+  * A Cognito Identity Pool with unauthenticated identity access enabled
+
 # Installation
 
 1. Open `./templates/saml1-api-template.yaml`

--- a/Scenario2/README.md
+++ b/Scenario2/README.md
@@ -20,6 +20,10 @@ For detailed walk-through see the original blog post located here: https://aws.a
 # Prerequsites
 This template will setup a sample application using SAML for authentication. It assumes you are using the following prerequsite blog: https://aws.amazon.com/blogs/security/enabling-federation-to-aws-using-windows-active-directory-adfs-and-saml-2-0/
 
+Prior to installation, you should setup the following in your AWS account:
+  * An S3 bucket in which to store the provided Serverless template
+  * A Cognito Identity Pool with unauthenticated identity access enabled
+
 In order to sign and JWT tokens you will need an encrypted plaintext key which will be stored in KMS.
  
 1. Navigate to the **IAM Console** and select Encryption Keys then Create Key. Type **sessionMaster** for your Alias and ensure in the Advanced Options KMS is selected then press Next Step. 


### PR DESCRIPTION
Updated the "Prerequisites" section for reach scenario's README.md to indicate that both an S3 bucket as well as a Cognito Identity Pool that has unauth access enabled should be created prior to installation.