### PR TITLE
Upgrade deprecated runtime nodejs4.3

### DIFF
--- a/Scenario1/templates/saml1-stack-sam.yaml
+++ b/Scenario1/templates/saml1-stack-sam.yaml
@@ -17,7 +17,7 @@ Resources:
     Properties:
       FunctionName: "redirect_awslabs_samldemo"
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs10.x
       Role: 
         Fn::GetAtt: 
           - "RedirectRole"

--- a/Scenario2/templates/saml2-stack-sam.yaml
+++ b/Scenario2/templates/saml2-stack-sam.yaml
@@ -38,7 +38,7 @@ Resources:
       Code: 
         S3Bucket: YOUR_S3_BUCKET
         S3Key: "generateKey.zip"
-      Runtime: "nodejs4.3"
+      Runtime: "nodejs10.x"
       Timeout: "30"
       Environment:
         Variables:
@@ -92,7 +92,7 @@ Resources:
       Code: 
         S3Bucket: YOUR_S3_BUCKET
         S3Key: "saml.zip"
-      Runtime: "nodejs4.3"
+      Runtime: "nodejs10.x"
       Timeout: "30"
       Environment:
         Variables:
@@ -154,7 +154,7 @@ Resources:
       Code: 
         S3Bucket: YOUR_S3_BUCKET
         S3Key: "custom_auth.zip"
-      Runtime: "nodejs4.3"
+      Runtime: "nodejs10.x"
       Timeout: "30"
       Environment:
         Variables:


### PR DESCRIPTION
CloudFormation templates in samljs-serverless-sample have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs4.3). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.